### PR TITLE
Sample updated with Yammer and Teams direct links (showed during Community call)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 .vscode
 bin
 obj
+samples/react-application-grouplinks/src/restQueries/group.http
+samples/react-application-grouplinks/src/restQueries/teamsGroup.http
+samples/react-application-grouplinks/src/restQueries/yammerGroup.http

--- a/samples/react-application-grouplinks/src/extensions/groupDirectLinks/GroupDirectLinksApplicationCustomizer.ts
+++ b/samples/react-application-grouplinks/src/extensions/groupDirectLinks/GroupDirectLinksApplicationCustomizer.ts
@@ -29,47 +29,55 @@ export interface IGroupDirectLinksApplicationCustomizerProperties {
 export default class GroupDirectLinksApplicationCustomizer
   extends BaseApplicationCustomizer<IGroupDirectLinksApplicationCustomizerProperties> {
 
-    private _headerPlaceholder: PlaceholderContent;
+  private _headerPlaceholder: PlaceholderContent;
 
-    @override
-    public onInit(): Promise<void> {
-      Log.info(LOG_SOURCE, `Initialized ${strings.Title}`);
-  
-      // Added to handle possible changes on the existence of placeholders
-      this.context.placeholderProvider.changedEvent.add(this, this._renderPlaceHolders);
-  
-      // Call render method for generating the needed html elements
-      this._renderPlaceHolders();
-  
-      return Promise.resolve();
-    }
-  
-    private _renderPlaceHolders(): void {
-      // Check if the header placeholder is already set and if the header placeholder is available
-      if (!this._headerPlaceholder && this.context.placeholderProvider.placeholderNames.indexOf(PlaceholderName.Top) !== -1) {
-        this._headerPlaceholder = this.context.placeholderProvider.tryCreateContent(PlaceholderName.Top, {
-          onDispose: this._onDispose
-        });
-  
-        // The extension should not assume that the expected placeholder is available.
-        if (!this._headerPlaceholder) {
-          console.error('The expected placeholder (PageHeader) was not found.');
-          return;
-        }
-  
-        if (this._headerPlaceholder.domElement) {
-          const element: React.ReactElement<IGroupDirectLinksProps> = React.createElement(
-            GroupDirectLinkInfo,
-            {
-              context: this.context
-            }
-          );
-          ReactDom.render(element, this._headerPlaceholder.domElement);
-        }
+  @override
+  public onInit(): Promise<void> {
+    console.log(`${LOG_SOURCE} Initialized ${strings.Title}. Property value: ${this.properties.testMessage}`);
+
+    // Added to handle possible changes on the existence of placeholders
+    this.context.placeholderProvider.changedEvent.add(this, this._renderPlaceHolders);
+
+    // Call render method for generating the needed html elements
+    this._renderPlaceHolders();
+
+    return Promise.resolve();
+  }
+
+  private _renderPlaceHolders(): void {    
+    if (this._headerPlaceholderAvailableAndNotCreatedYet()) {
+
+      this._headerPlaceholder = this.context.placeholderProvider.tryCreateContent(PlaceholderName.Top, {
+        onDispose: this._onDispose
+      });
+
+      // The extension should not assume that the expected placeholder is available.
+      if (!this._headerPlaceholder) {
+        console.error(`${LOG_SOURCE} The expected placeholder (PageHeader) was not found.`);
+        return;
       }
+
+      if (this._headerPlaceholder.domElement) {
+        const element: React.ReactElement<IGroupDirectLinksProps> = React.createElement(
+          GroupDirectLinkInfo,
+          {
+            context: this.context
+          }
+        );
+        ReactDom.render(element, this._headerPlaceholder.domElement);
+      }
+
     }
-  
-    private _onDispose(): void {
-      console.log('[Breadcrumb._onDispose] Disposed breadcrumb.');
-    }
+  }
+
+  private _headerPlaceholderAvailableAndNotCreatedYet(): boolean
+  {
+    // Check if the header placeholder is already set and if the header placeholder is available
+    return !this._headerPlaceholder 
+      && this.context.placeholderProvider.placeholderNames.indexOf(PlaceholderName.Top) !== -1;
+  }
+
+  private _onDispose(): void {
+    console.log(`${LOG_SOURCE} Dispossed`);
+  }
 }

--- a/samples/react-application-grouplinks/src/extensions/groupDirectLinks/components/IGroupDirectLinks.ts
+++ b/samples/react-application-grouplinks/src/extensions/groupDirectLinks/components/IGroupDirectLinks.ts
@@ -17,4 +17,6 @@ export interface IGroupDirectLinksInfo {
   isPublic?: boolean;
   notebookUrl?: string;
   peopleUrl?: string;
+  yammerUrl?: string;
+  teamsUrl?: string;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no

#### What's in this Pull Request?

This new version of the sample includes the Yammer and Teams direct link into the Group direct links Header extension. This is the version I showed during the March monthly Community call.