### PR TITLE
Changed package-lock.json to rollback malware version of event-stream

### DIFF
--- a/samples/react-application-injectcss/package-lock.json
+++ b/samples/react-application-injectcss/package-lock.json
@@ -7881,7 +7881,7 @@
         "ansi-colors": "1.1.0",
         "connect": "3.6.6",
         "connect-livereload": "0.5.4",
-        "event-stream": "3.3.6",
+        "event-stream": "3.3.5",
         "fancy-log": "1.3.2",
         "send": "0.13.2",
         "serve-index": "1.9.1",
@@ -7904,19 +7904,18 @@
           "dev": true
         },
         "event-stream": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-          "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+          "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1",
-            "flatmap-stream": "0.1.1",
-            "from": "0.1.7",
+            "duplexer": "^0.1.1",
+            "from": "^0.1.7",
             "map-stream": "0.0.7",
-            "pause-stream": "0.0.11",
-            "split": "1.0.1",
-            "stream-combiner": "0.2.2",
-            "through": "2.3.8"
+            "pause-stream": "^0.0.11",
+            "split": "^1.0.1",
+            "stream-combiner": "^0.2.2",
+            "through": "^2.3.8"
           }
         },
         "fresh": {


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | - |

## What's in this Pull Request?

Changed package-lock.json of "react-application-injectcss" example so that `npm install` does not try to install event-stream 3.3.6 anymore (see https://github.com/dominictarr/event-stream/issues/116).
