### PR TITLE
Update react-menu-footer-classic-modern - fix for classic nav position

### DIFF
--- a/samples/react-menu-footer-classic-modern/Classic/client/bootHeaderFooter.ts
+++ b/samples/react-menu-footer-classic-modern/Classic/client/bootHeaderFooter.ts
@@ -11,10 +11,11 @@ export class bootstrapper {
     const footer = document.createElement("div");
 
     // Insert the header and footer on the page
+    const ribbon = document.getElementById('s4-ribbonrow');
     const workspace = document.getElementById('s4-workspace');
     if (workspace) {
 
-      workspace.parentElement.insertBefore(header,workspace);
+      ribbon.parentElement.insertBefore(header,ribbon);
       workspace.appendChild(footer);
 
       // For now this is hard-coded
@@ -29,10 +30,10 @@ export class bootstrapper {
         .catch ((error: string) => {
           console.log(`Error in CustomHeaderFooterApplicationCustomizer: ${error}`);
         });
-  
+
     } else {
 
-      // The elemement we want to attach to is missing
+      // The element we want to attach to is missing
       console.log('Error in CustomHeaderFooterApplicationCustomizer: Unable to find element to attach header and footer');
       
     }

--- a/samples/react-menu-footer-classic-modern/SPFx/src/extensions/customHeaderFooter/CustomHeaderFooterApplicationCustomizer.ts
+++ b/samples/react-menu-footer-classic-modern/SPFx/src/extensions/customHeaderFooter/CustomHeaderFooterApplicationCustomizer.ts
@@ -26,12 +26,18 @@ export default class CustomHeaderFooterApplicationCustomizer
 
   @override
   public onInit(): Promise<void> {
-    Log.info(LOG_SOURCE, `Initialized CustomHeaderFooterApplicationCustomizer`);
+    return new Promise(() => {
+      Log.info(LOG_SOURCE, `Initialized CustomHeaderFooterApplicationCustomizer`);
 
-    // New promise to give back to SPFx and resolve
-    // or reject when we're done
-    const promise = new Promise<void>((resolve, reject) => {
+      //Utilize placeholderProvider changed event to trigger bootstrapping header and footer.
+      this.context.placeholderProvider.changedEvent.add(this, this.bootstrap);
 
+      return;
+    });
+  }
+
+  private bootstrap(): void {
+    
     // For now this is hard-coded
     // -- UPLOAD JSON WITH MENU CONTENTS AND PUT THE URL HERE --
     const url = 'https://<tenant>.sharepoint.com/sites/scripts/Style%20Library/HeaderFooterData.json.txt';
@@ -56,16 +62,12 @@ export default class CustomHeaderFooterApplicationCustomizer
               footer ? footer.domElement : null, data);
           }
 
-          // Tell SPFx we are done
-          resolve();
         })
         .catch ((error: string) => {
           console.log(`Error in CustomHeaderFooterApplicationCustomizer: ${error}`);
-          reject();
         });
-    });
-
-    return promise;
+  
+    return;
   }
 
   private _onDispose(): void { }


### PR DESCRIPTION
Update to use changedEvent handler
Update to better position header on classic pages, to not be behind ribbon.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |

## What's in this Pull Request?

Currently the header is positioned in classic so that it is hidden by the ribbon. This PR correctly positions the header before s4-ribbonrow instead of s4-workspace and utilizes the changedEvent to bootstrap the component into the header/footer.

