### PR TITLE
Added tenant wide deployment compatibility and moved the instrumentation key to properties

### DIFF
--- a/samples/js-application-appinsights/README.md
+++ b/samples/js-application-appinsights/README.md
@@ -56,7 +56,7 @@ This extension injects the Application Insights javascript code along with the s
 <br />
 The actual code is in `src\extensions\appInsights\AppInsightsApplicationCustomizer.ts`.
 <br />
-The instrumentation key of the Azure Application Insights ressource to use is stored in several locations:
+The instrumentation key of the Azure Application Insights resource to use is stored in several locations:
 * When running a gulp serve and running the page in debug mode, the key that is stored in `config\serve.json` is passed to the page as querystring.
 * When the extension is installed on a site, the key in `sharepoint\assets\elements.xml` is used.
 * When deployed tenant wide, the key in `sharepoint\assets\ClientSideInstance.xml` is used.

--- a/samples/js-application-appinsights/README.md
+++ b/samples/js-application-appinsights/README.md
@@ -7,7 +7,7 @@ This sample implements the code needed for browser usage analysis, as described 
 ![Application Insights Customizer Customizer](https://github.com/SharePoint/sp-dev-fx-extensions/blob/master/samples/js-application-appinsights/assets/appinsights-1.png)
 
 ## Used SharePoint Framework Version 
-![drop](https://img.shields.io/badge/version-GA-green.svg)
+![drop](https://img.shields.io/badge/SPFx-1.9.1-green.svg)
 
 ## Applies to
 

--- a/samples/js-application-appinsights/README.md
+++ b/samples/js-application-appinsights/README.md
@@ -1,7 +1,7 @@
 # Injecting Javascript with Sharepoint Framework Extensions - Azure Application Insights
 
 ## Summary
-Sample SharePoint Framework extension projects injecting Javascript code to enable Azure App Insights monitoring and statistics.
+Sample SharePoint Framework extension project injecting Javascript code to enable Azure App Insights monitoring and statistics.
 This sample implements the code needed for browser usage analysis, as described here: https://docs.microsoft.com/azure/azure-monitor/app/usage-overview
 
 ![Application Insights Customizer Customizer](https://github.com/SharePoint/sp-dev-fx-extensions/blob/master/samples/js-application-appinsights/assets/appinsights-1.png)
@@ -21,12 +21,13 @@ This sample implements the code needed for browser usage analysis, as described 
 
 Solution|Author(s)
 --------|---------
-js-application-appinsights  | Version 1: Luis Valencia (MVP)<br />Version 2: Guillaume Sellier (Premier Field Engineer - Microsoft)
+js-application-appinsights  |- Version 2: Guillaume Sellier (Premier Field Engineer - Microsoft)<br />- Version 1: Luis Valencia (MVP)
 
 ## Version history
 
 Version|Date|Comments
 -------|----|--------
+2.1|August 28, 2019|- Store the Application Insights instrumentation key as a component property so that it is not pushed to the CDN with the JS files<br />- Made the solution compatible with tenant wide deployment<br />- Updated the solution to target SPFx 1.9.1
 2.0|July 29, 2019|Rebuilt the sample to make it work with SPFx 1.8.2
 1.0|June 11, 2017|Initial release
 
@@ -38,16 +39,31 @@ Version|Date|Comments
 ## Minimal Path to Awesome
 
 - Clone this repository
-- In `src\extensions\appInsights\AppInsightsApplicationCustomizer.ts`, update the variable `appInsightsKey` with your Azure Application Insights Instrumentation Key
-- In `config\serve.json`, update your debug site url
+- Update your Azure Application Insights Instrumentation Key (see next section for the locations of the key)
 - In the command line run:
   - `npm install`
-  - `gulp serve`
+  - For debugging:
+    - `gulp serve`
+  - To generate the production package:
+    - `gulp bundle --ship`
+    - `gulp package-solution --ship`
+    - Install the package on a site or tenant wide
 - Navigate on your site
-- After a few seconds, usage data will be visible in Application Insights
+- After a few seconds, usage data will be visible in Azure Application Insights
 
+## How it works
+This extension injects the Application Insights javascript code along with the specified instrumentation key in the head of the webpage.
+<br />
+The actual code is in `src\extensions\appInsights\AppInsightsApplicationCustomizer.ts`.
+<br />
+The instrumentation key of the Azure Application Insights ressource to use is stored in several locations:
+* When running a gulp serve and running the page in debug mode, the key that is stored in `config\serve.json` is passed to the page as querystring.
+* When the extension is installed on a site, the key in `sharepoint\assets\elements.xml` is used.
+* When deployed tenant wide, the key in `sharepoint\assets\ClientSideInstance.xml` is used.
+    * In tenant wide deployments, you can easily edit the key in the Tenant Wide Extensions list of your tenant app catalog.
+> <b>Note</b>: If you put your key directly in `src\extensions\appInsights\AppInsightsApplicationCustomizer.ts` instead of using parameters, it could be pushed to the Office 365 Public CDN along with the JS files if it is enabled on your tenant.
 
 ## Features
-This extension injects javascript needed to track pages in Sharepoint Online with Azure Application Insights
+This extension injects javascript needed to track pages in SharePoint Online with Azure Application Insights
 
 <img src="https://telemetry.sharepointpnp.com/sp-dev-fx-extensions/samples/js-application-appinsights" />

--- a/samples/js-application-appinsights/config/package-solution.json
+++ b/samples/js-application-appinsights/config/package-solution.json
@@ -3,15 +3,16 @@
   "solution": {
     "name": "app-insights-client-side-solution",
     "id": "a42bc34e-4081-41b9-af32-dd01cdf6c211",
-    "version": "2.0.0.0",
+    "version": "2.1.0.0",
     "includeClientSideAssets": true,
+    "skipFeatureDeployment": true,
     "isDomainIsolated": false,
     "features": [
       {
         "title": "Application Extension - Deployment of custom action.",
         "description": "Deploys a custom action with ClientSideComponentId association",
         "id": "b590469c-fef8-456b-b038-d5c58c9e57ae",
-        "version": "2.0.0.0",
+        "version": "2.1.0.0",
         "assets": {
           "elementManifests": [
             "elements.xml",

--- a/samples/js-application-appinsights/config/serve.json
+++ b/samples/js-application-appinsights/config/serve.json
@@ -9,7 +9,7 @@
         "5e627b50-6e2b-418e-96c9-14f4a8e0507c": {
           "location": "ClientSideExtension.ApplicationCustomizer",
           "properties": {
-            "testMessage": "Test message"
+            "appInsightsKey": "a09f32d3-479e-4782-b6db-1bdce04536db"
           }
         }
       }
@@ -20,7 +20,7 @@
         "5e627b50-6e2b-418e-96c9-14f4a8e0507c": {
           "location": "ClientSideExtension.ApplicationCustomizer",
           "properties": {
-            "testMessage": "Test message"
+            "appInsightsKey": "a09f32d3-479e-4782-b6db-1bdce04536db"
           }
         }
       }

--- a/samples/js-application-appinsights/package-lock.json
+++ b/samples/js-application-appinsights/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-insights",
-  "version": "0.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,14 +25,14 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.0.42",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.0.42.tgz",
-      "integrity": "sha512-7W6NZV+HdoaEjBlzIZ8084TsEJ0lj6t0CE2uwB4IILo+b5CpOndhkBUQt0uAqKYQHRS6DrJwqFzB4PkhcOquMg==",
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.1.8.tgz",
+      "integrity": "sha512-7fcGbnOp7bmQe4p1b123K6gJ/qyaLWhufSt5OF3DMMK1JbmdfEGWf7AwyFFSS4QQzPvSxqs8Woehye4Ytf1uAA==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.0.28",
+        "@microsoft/api-extractor-model": "7.1.3",
         "@microsoft/node-core-library": "3.13.0",
-        "@microsoft/ts-command-line": "4.2.3",
+        "@microsoft/ts-command-line": "4.2.5",
         "@microsoft/tsdoc": "0.12.9",
         "colors": "~1.2.1",
         "lodash": "~4.17.5",
@@ -50,28 +50,20 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.0.28.tgz",
-      "integrity": "sha512-kZJaWwdu3z5A1DugJpOZ9dI5+DjIEhqQJwHn2/kLTpsKT7gOyqNRbGHlDGG8xSiJ6/m994+cwh3qSGYDC17dtw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.1.3.tgz",
+      "integrity": "sha512-DjagaoMFY1XyLjjo/x4lp7LoyjyMg4ntDY5+RE8g2zvt61m2dKm9CtxW0lxaQI4Xilw+n+Z4exjcGaQJeRcMyw==",
       "dev": true,
       "requires": {
         "@microsoft/node-core-library": "3.13.0",
-        "@microsoft/tsdoc": "0.12.8",
+        "@microsoft/tsdoc": "0.12.9",
         "@types/node": "8.5.8"
-      },
-      "dependencies": {
-        "@microsoft/tsdoc": {
-          "version": "0.12.8",
-          "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.8.tgz",
-          "integrity": "sha512-0smzAmVIUCsssAqDSPn9AfOPKUobq2WXMygbzC5JNswAJOs4uJK6DTZgfnHC8QLE2q374sPNwWU5D5LuoAJQSA==",
-          "dev": true
-        }
       }
     },
     "@microsoft/decorators": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.8.2.tgz",
-      "integrity": "sha512-1tWDtxh6Mks5JjqI2yRPBD3ZaOT1DhDh6+Z/Lj1LWA+OU4CnIkl2P3uGkiKhchXlgHBeKUidFGRVrv0parfTRQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/decorators/-/decorators-1.9.1.tgz",
+      "integrity": "sha512-Pn6Ij6Z8vRqL8v43RPHBlCJmJYmWTxL/oBHc8hPR0nhNaJN5kFrrGfEjhXN3MqJL8W5+HWR5Kb6v65TS01Gapg==",
       "requires": {
         "tslib": "~1.9.3"
       }
@@ -259,9 +251,9 @@
               }
             },
             "node-notifier": {
-              "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-              "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+              "version": "5.4.3",
+              "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+              "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
               "dev": true,
               "requires": {
                 "growly": "^1.3.0",
@@ -272,9 +264,9 @@
               }
             },
             "semver": {
-              "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true
             },
             "yargs": {
@@ -347,14 +339,14 @@
       }
     },
     "@microsoft/gulp-core-build-sass": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-sass/-/gulp-core-build-sass-4.6.2.tgz",
-      "integrity": "sha512-QUI/5iWt5+gl2DyeTTULzzs/oSYmoRFkCXMOGW0FTQbE6pjPvGX6Za+jaCYyFwoURaXMTRvcAKbxZAzFBYSUWw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-sass/-/gulp-core-build-sass-4.7.3.tgz",
+      "integrity": "sha512-gKgaAcd7fKMLhSkjk//p4cWAKVOLvQoc67T5IuGgUffWjK6KQ6TJWYfF/VypCZpPLzCJbCjeqk1qA/Qj09jkfg==",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build": "3.9.7",
-        "@microsoft/load-themed-styles": "1.8.59",
-        "@microsoft/node-core-library": "3.10.0",
+        "@microsoft/gulp-core-build": "3.9.26",
+        "@microsoft/load-themed-styles": "1.9.5",
+        "@microsoft/node-core-library": "3.13.0",
         "@types/gulp": "3.8.32",
         "@types/node": "8.5.8",
         "autoprefixer": "~9.1.3",
@@ -365,129 +357,11 @@
         "postcss-modules": "~1.3.1"
       },
       "dependencies": {
-        "@microsoft/gulp-core-build": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-3.9.7.tgz",
-          "integrity": "sha512-Lv4zEXn1MgTxj+NkvMpgO1GqvmbF3yW5OXLuwrVZIIXKsl5Rb/R8P725NIUo5EC/loUhZGvLuUNGxIzAl4WUWA==",
-          "dev": true,
-          "requires": {
-            "@microsoft/node-core-library": "3.10.0",
-            "@types/assertion-error": "1.0.30",
-            "@types/chai": "3.4.34",
-            "@types/chalk": "0.4.31",
-            "@types/gulp": "3.8.32",
-            "@types/mocha": "5.2.5",
-            "@types/node": "8.5.8",
-            "@types/node-notifier": "0.0.28",
-            "@types/orchestrator": "0.0.30",
-            "@types/q": "0.0.32",
-            "@types/semver": "5.3.33",
-            "@types/through2": "2.0.32",
-            "@types/vinyl": "1.2.30",
-            "@types/yargs": "0.0.34",
-            "colors": "~1.2.1",
-            "del": "^2.2.2",
-            "end-of-stream": "~1.1.0",
-            "glob-escape": "~0.0.1",
-            "globby": "~5.0.0",
-            "gulp": "~3.9.1",
-            "gulp-flatten": "~0.2.0",
-            "gulp-if": "^2.0.1",
-            "jest": "~23.6.0",
-            "jest-cli": "~22.4.3",
-            "jest-environment-jsdom": "~22.4.3",
-            "jest-resolve": "~22.4.3",
-            "jsdom": "~11.11.0",
-            "lodash.merge": "~4.3.2",
-            "merge2": "~1.0.2",
-            "node-notifier": "~5.0.2",
-            "object-assign": "~4.1.0",
-            "orchestrator": "~0.3.8",
-            "pretty-hrtime": "~1.0.2",
-            "semver": "~5.3.0",
-            "through2": "~2.0.1",
-            "vinyl": "~2.2.0",
-            "yargs": "~4.6.0",
-            "z-schema": "~3.18.3"
-          }
-        },
         "@microsoft/load-themed-styles": {
-          "version": "1.8.59",
-          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.59.tgz",
-          "integrity": "sha512-FbOAj3EaGgexBGUKvvGRHzsDEmtlbCvgnqhkX754Oh7lDCX2RSjg080nM1TW/rOPYDZReixeyC0uO541Rt9w6Q==",
+          "version": "1.9.5",
+          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.5.tgz",
+          "integrity": "sha512-eCKOefBFZnF6aruNxUYN6KR728BPDTDqzucEnjhPDXI3zkci2OJ5h4jBiUtVLLOJLtLI0Vg8Vcg1t2BQb/7SeA==",
           "dev": true
-        },
-        "@microsoft/node-core-library": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.10.0.tgz",
-          "integrity": "sha512-1SbU+XNYAabhV9noGXHtsUVPc5ELV+oEuJQtZQoCncbOd6WAMeTgB1xFwh96hmdEXyKQyML/pnByiKocmh/nbQ==",
-          "dev": true,
-          "requires": {
-            "@types/fs-extra": "5.0.4",
-            "@types/jju": "~1.4.0",
-            "@types/node": "8.5.8",
-            "@types/z-schema": "3.16.31",
-            "colors": "~1.2.1",
-            "fs-extra": "~7.0.1",
-            "jju": "~1.4.0",
-            "z-schema": "~3.18.3"
-          }
-        },
-        "@types/mocha": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-          "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
         },
         "glob": {
           "version": "7.0.6",
@@ -502,193 +376,13 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "jest": {
-          "version": "23.6.0",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-          "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
-          "dev": true,
-          "requires": {
-            "import-local": "^1.0.0",
-            "jest-cli": "^23.6.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "jest-cli": {
-              "version": "23.6.0",
-              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-              "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "import-local": "^1.0.0",
-                "is-ci": "^1.0.10",
-                "istanbul-api": "^1.3.1",
-                "istanbul-lib-coverage": "^1.2.0",
-                "istanbul-lib-instrument": "^1.10.1",
-                "istanbul-lib-source-maps": "^1.2.4",
-                "jest-changed-files": "^23.4.2",
-                "jest-config": "^23.6.0",
-                "jest-environment-jsdom": "^23.4.0",
-                "jest-get-type": "^22.1.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve-dependencies": "^23.6.0",
-                "jest-runner": "^23.6.0",
-                "jest-runtime": "^23.6.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "jest-watcher": "^23.4.0",
-                "jest-worker": "^23.2.0",
-                "micromatch": "^2.3.11",
-                "node-notifier": "^5.2.1",
-                "prompts": "^0.1.9",
-                "realpath-native": "^1.0.0",
-                "rimraf": "^2.5.4",
-                "slash": "^1.0.0",
-                "string-length": "^2.0.0",
-                "strip-ansi": "^4.0.0",
-                "which": "^1.2.12",
-                "yargs": "^11.0.0"
-              }
-            },
-            "jest-environment-jsdom": {
-              "version": "23.4.0",
-              "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-              "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
-              "dev": true,
-              "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0",
-                "jsdom": "^11.5.1"
-              }
-            },
-            "node-notifier": {
-              "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-              "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
-              "dev": true,
-              "requires": {
-                "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-              "dev": true
-            },
-            "yargs": {
-              "version": "11.1.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-              "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-              "dev": true,
-              "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
         }
       }
     },
     "@microsoft/gulp-core-build-serve": {
-      "version": "3.3.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-serve/-/gulp-core-build-serve-3.3.29.tgz",
-      "integrity": "sha512-TD6G1Mj7mYQD0LET9/96XABRqeqC+Nr+SrxNH1uWGG4ffV4hBnZEbECH+BeeT0tdnpocF1pDVoym8ZQ7LU95Qw==",
+      "version": "3.3.39",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-serve/-/gulp-core-build-serve-3.3.39.tgz",
+      "integrity": "sha512-M5v8Ur3xg0hFrVjo4rilMhC09H3fvhRduZyq/ffNhcxa+LzUc5Wd98BF48/KAbKhJ5noHGg5eONHL/+mhuQDWA==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
@@ -705,9 +399,9 @@
       }
     },
     "@microsoft/gulp-core-build-typescript": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-8.1.5.tgz",
-      "integrity": "sha512-nHhvEaO5v/HidGut42lXflv9eeaDWmPJp76TIx41qEbyqRTPsRvbZVpQJ2avOCZrrLv4hUZNr24+wcghjQ0XkA==",
+      "version": "8.1.14",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-8.1.14.tgz",
+      "integrity": "sha512-FWA6Qb3mE/YXeFTqIbWkWZ27xh0W6KLKgp4xjrgIXAhXwRzo1YJGoXHMcd5rp2WUHmNPLj94fi8WHIp6nB5oXQ==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
@@ -736,9 +430,9 @@
       }
     },
     "@microsoft/gulp-core-build-webpack": {
-      "version": "3.4.96",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-3.4.96.tgz",
-      "integrity": "sha512-y4SvyAjXOU1Y4DAlCfN0k2o7mYpt25yx41pELHUpLy4OLRoq3+HrvAbscKnG3KueiPu9GwV62dTDgin2Qu3ebQ==",
+      "version": "3.4.106",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-3.4.106.tgz",
+      "integrity": "sha512-mX1mCgumwrLrNUvEK/PNmKrhyeasO7+Rqk8DjX4gnT/WMBUb+SjKyMBM1rQaIotUReYXHMhmWcMsqZXDDOYHxw==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
@@ -954,19 +648,19 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.15.tgz",
-      "integrity": "sha512-bhm4T+tZ/OcrpehW1q1tuElGvxT7WT6s+1Aqz7Yg7UZDA9xyZkQDNb/BY9f4GjJ8t82EedwJxYJQwaGQfTngfg=="
+      "version": "1.9.19",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.19.tgz",
+      "integrity": "sha512-t4jHLmQtL9ORfGlAXOAIBJlsCa9QfhNhTbL4TrnsbNJ55HS6SLUULbwvbJTwmw+D9WGuM8d+HpkkkpM5N3T6IA=="
     },
     "@microsoft/loader-cased-file": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-cased-file/-/loader-cased-file-1.8.2.tgz",
-      "integrity": "sha512-yMsWqgkICwMjqDvuEXM6ANDJCcaL7iQE5So2115MSBKpkHuKNAzL8KC/jG0ko8duO9M908/UuxTrpK+XiejfqA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-cased-file/-/loader-cased-file-1.9.1.tgz",
+      "integrity": "sha512-JS//AaEvH95l9Q+mMW6T0WU+B+VyqoPa2IxmZMW9u9Fr5DoGGE3awi1DP6n62J/ThFEuRHDe3opXF6iox50rBA==",
       "dev": true,
       "requires": {
         "@types/lodash": "4.14.117",
         "@types/node": "8.5.8",
-        "file-loader": "~1.1.5",
+        "file-loader": "~1.1.11",
         "loader-utils": "~1.1.0",
         "lodash": "~4.17.5"
       },
@@ -985,19 +679,19 @@
       }
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.127",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.127.tgz",
-      "integrity": "sha512-D9gxcuePnQqUHJ4hY4gfbQfwdZLUdxFyzKOXXB+YM2NL+lHyg08lqpOijjOcU3fvEAw4hA4bCaidScQVWImwmA==",
+      "version": "1.7.163",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.163.tgz",
+      "integrity": "sha512-XScBqk3U4N/flRkDzFDKJUD3DM6QkWPP+QiwkIZRYR8amqCbbI4JpjA9U+8kZ0CiBSEBPRrLNtZWUMCzGV6g3g==",
       "dev": true,
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.59",
+        "@microsoft/load-themed-styles": "1.9.5",
         "loader-utils": "~1.1.0"
       },
       "dependencies": {
         "@microsoft/load-themed-styles": {
-          "version": "1.8.59",
-          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.59.tgz",
-          "integrity": "sha512-FbOAj3EaGgexBGUKvvGRHzsDEmtlbCvgnqhkX754Oh7lDCX2RSjg080nM1TW/rOPYDZReixeyC0uO541Rt9w6Q==",
+          "version": "1.9.5",
+          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.5.tgz",
+          "integrity": "sha512-eCKOefBFZnF6aruNxUYN6KR728BPDTDqzucEnjhPDXI3zkci2OJ5h4jBiUtVLLOJLtLI0Vg8Vcg1t2BQb/7SeA==",
           "dev": true
         },
         "loader-utils": {
@@ -1039,48 +733,47 @@
       }
     },
     "@microsoft/office-ui-fabric-react-bundle": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.8.2.tgz",
-      "integrity": "sha512-KQ07naCdJXW6nquDDEP/ydb8SHoFj1Kcsldj5qREcdJIZfUkrlxXRpFlgJoVKdPF3sYomDSssTCQf8pmy0uicA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.9.1.tgz",
+      "integrity": "sha512-crBGH0boDycyvK5VkGMEatDW4wJhykPn3Pk4wBJmuHw1Ya0G0uORf0GG4yojX5AF9MfCIqj4trhQu1NX6hvPLA==",
       "requires": {
-        "@types/react": "16.4.2",
+        "@types/react": "16.8.8",
         "@types/webpack-env": "1.13.1",
-        "@uifabric/icons": "6.4.0",
-        "office-ui-fabric-react": "6.143.0",
-        "react": "16.7.0",
-        "react-dom": "16.7.0",
+        "@uifabric/icons": "6.5.3",
+        "office-ui-fabric-react": "6.189.2",
+        "react": "16.8.5",
+        "react-dom": "16.8.5",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/package-deps-hash": {
-      "version": "2.2.100",
-      "resolved": "https://registry.npmjs.org/@microsoft/package-deps-hash/-/package-deps-hash-2.2.100.tgz",
-      "integrity": "sha512-cRQeF3/USg6OrZBnr3Q1cI0jcov1gse0tr05Pj0GXmfmsw0EhGqmeBsm5wzOFamnfwJ0zXLIqAi8wLfCm7n8nw==",
+      "version": "2.2.158",
+      "resolved": "https://registry.npmjs.org/@microsoft/package-deps-hash/-/package-deps-hash-2.2.158.tgz",
+      "integrity": "sha512-gN0vkVrF38flbxbPJlEEGJi72Hxqn9JFYILCs0rOSL+LZOGuKUzaZYm3B7XbX7GF6LzPs2R3T5gmWx1EHxxQAQ==",
       "dev": true
     },
     "@microsoft/rush-lib": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.5.2.tgz",
-      "integrity": "sha512-nfTdC2HNun0Swd3/WlUMaCSF7vkAZoag15FfLi2skjqZYpvEdgRPP4ufzs5LctGRbCSVESMCfP0UrPPXrsqplA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.9.1.tgz",
+      "integrity": "sha512-Ytjvy4TJ9w1ryokAN5BKe3R3vLx2jAkUal07EwAu1Kuv65pML/FZj26OPHesOq01+ly/PEdZeOwnBFme7rZCiA==",
       "dev": true,
       "requires": {
-        "@microsoft/node-core-library": "3.5.2",
-        "@microsoft/package-deps-hash": "2.2.100",
-        "@microsoft/stream-collator": "3.0.15",
-        "@microsoft/ts-command-line": "4.2.2",
+        "@microsoft/node-core-library": "3.13.0",
+        "@microsoft/package-deps-hash": "2.2.158",
+        "@microsoft/stream-collator": "3.0.73",
+        "@microsoft/ts-command-line": "4.2.6",
         "@pnpm/link-bins": "~1.0.1",
         "@pnpm/logger": "~1.0.1",
         "@types/inquirer": "0.0.43",
         "@yarnpkg/lockfile": "~1.0.2",
         "builtins": "~1.0.3",
         "colors": "~1.2.1",
-        "git-repo-info": "~1.1.4",
+        "git-repo-info": "~2.1.0",
         "glob": "~7.0.5",
         "glob-escape": "~0.0.1",
         "https-proxy-agent": "~2.2.1",
         "inquirer": "~6.2.0",
-        "jju": "~1.3.0",
-        "js-yaml": "~3.9.1",
+        "js-yaml": "~3.13.1",
         "lodash": "~4.17.5",
         "minimatch": "~3.0.2",
         "node-fetch": "~2.1.2",
@@ -1093,25 +786,10 @@
         "z-schema": "~3.18.3"
       },
       "dependencies": {
-        "@microsoft/node-core-library": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.5.2.tgz",
-          "integrity": "sha512-2zDWLqJ/ABjxtk0thb//bohWEFGOLKQ7gjfAS6cfCcpyVXX08qvO79pb0eGOvNXi2ggfuuKsoEIRXl6idbV7UQ==",
-          "dev": true,
-          "requires": {
-            "@types/fs-extra": "5.0.4",
-            "@types/node": "8.5.8",
-            "@types/z-schema": "3.16.31",
-            "colors": "~1.2.1",
-            "fs-extra": "~7.0.1",
-            "jju": "~1.3.0",
-            "z-schema": "~3.18.3"
-          }
-        },
         "@microsoft/ts-command-line": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.2.tgz",
-          "integrity": "sha512-CLLVG+zWmUvD6jZD5oq7QCFYj3WOvrBSc3H6KejXCH6q2ntP5/ZHlmKVzQVvN1cEOSWP+jN9ml2AvUcDY/l6Tw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.6.tgz",
+          "integrity": "sha512-GFLPg9Z5yiNca3di/V6Zt3tAvj1de9EK0eL88tE+1eckQSH405UQcm7D+H8LbEhRpqpG+ZqN9LXCAEw4L5uchg==",
           "dev": true,
           "requires": {
             "@types/argparse": "1.0.33",
@@ -1132,22 +810,6 @@
             "minimatch": "^3.0.2",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "jju": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-          "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-          "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "node-fetch": {
@@ -1192,12 +854,12 @@
       }
     },
     "@microsoft/rush-stack-compiler-2.9": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/rush-stack-compiler-2.9/-/rush-stack-compiler-2.9-0.7.7.tgz",
-      "integrity": "sha512-hhtSK+aQWGEkGucHf7fJx+5aokc9SAPL2+Jo5Nj4vPRGfEuuWFYrIxLk0EpHJtloosgk3ViLWnFl5vKXN+9yMA==",
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush-stack-compiler-2.9/-/rush-stack-compiler-2.9-0.7.16.tgz",
+      "integrity": "sha512-a3sHfyEYj1aPgd87DYDX1InyP7YMYGRg6w62Ems0sLM67gUni6JGqKwLjqPsfFe9pKoT9hXvv1ltkTvxqh629g==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor": "7.0.42",
+        "@microsoft/api-extractor": "7.1.8",
         "@microsoft/node-core-library": "3.13.0",
         "@types/node": "8.5.8",
         "tslint": "~5.12.1",
@@ -1206,9 +868,9 @@
       }
     },
     "@microsoft/set-webpack-public-path-plugin": {
-      "version": "2.1.78",
-      "resolved": "https://registry.npmjs.org/@microsoft/set-webpack-public-path-plugin/-/set-webpack-public-path-plugin-2.1.78.tgz",
-      "integrity": "sha512-Nbvu6GxRev/5QsOhYrpBq5T3RSXvTUO45nA7lef2PPsreJ9EmPFkwVh/1mLpm3xtCZ8NOtMFEf2RphCAj2VCew==",
+      "version": "2.1.113",
+      "resolved": "https://registry.npmjs.org/@microsoft/set-webpack-public-path-plugin/-/set-webpack-public-path-plugin-2.1.113.tgz",
+      "integrity": "sha512-sUkEUjibw2iuBAHDEGc+oqPr4VC6Fx2rStqRfqv+yA+uOAit0kYDxVN5LBCkhYUWBGAPV2I/Ceb9mEF++/UGeA==",
       "dev": true,
       "requires": {
         "@types/node": "8.5.8",
@@ -1243,35 +905,35 @@
       }
     },
     "@microsoft/sp-application-base": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.8.2.tgz",
-      "integrity": "sha512-kpsp4Hby6nIPVR9QnHWZqF5QMV7lsYHaIkgg/NDLv4BDaIvvR9YnPAPeXas0Z6I6ovIwzo/o5WbTelTac/K4rw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-application-base/-/sp-application-base-1.9.1.tgz",
+      "integrity": "sha512-pY1JWFl+suxJmvXUI0ATdTN4eODXq8CMiTFL7aCQ+3NhAVjKOtzXkYR4lFjvWJdYoKsmhXVglzf19tMXJ5l4rg==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/sp-component-base": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-extension-base": "1.8.2",
-        "@microsoft/sp-http": "1.8.2",
-        "@microsoft/sp-loader": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-odata-types": "1.8.2",
-        "@microsoft/sp-page-context": "1.8.2",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/sp-component-base": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-extension-base": "1.9.1",
+        "@microsoft/sp-http": "1.9.1",
+        "@microsoft/sp-loader": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-odata-types": "1.9.1",
+        "@microsoft/sp-page-context": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-build-common": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-common/-/sp-build-common-1.8.2.tgz",
-      "integrity": "sha512-ta6slcsMf62pdt50D9J2bnDaYi5XQcwpadGr/cN6Nl2mXWpSF+MvL2cch54vcohnFRWDQ6QwmLuuKpqGtU4TUA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-common/-/sp-build-common-1.9.1.tgz",
+      "integrity": "sha512-ArDz6N2kDS9uCVmu84uYxIs/wgj/Bw5hQA5XUqVo8v9GtiX2tdQ5HcdFVJj/HbKUgN+wKbUP7uMj38PistCcSQ==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
-        "@microsoft/gulp-core-build-typescript": "8.1.5",
-        "@microsoft/sp-tslint-rules": "1.8.2",
+        "@microsoft/gulp-core-build-typescript": "8.1.14",
+        "@microsoft/sp-tslint-rules": "1.9.1",
         "@types/yargs": "0.0.35",
         "gulp": "~3.9.1",
         "semver": "~5.2.0",
@@ -1293,21 +955,21 @@
       }
     },
     "@microsoft/sp-build-core-tasks": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.8.2.tgz",
-      "integrity": "sha512-0rVg8N5XCbpM2Fefqx+5ZhiRm8l2xZLXctR0Z43aYXX5VKChVtuwv6lDf9xgDBvSudA5yOAT4dNDtEZ+XKitLA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.9.1.tgz",
+      "integrity": "sha512-Gg+lovd7qIqNkJHITvZ23bSyd+FqtLiG81T5gC1b7/GLR0edPiAXDxyfsAZNkj100LZkLD8h+oJEOi7M2mQMrQ==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
-        "@microsoft/gulp-core-build-serve": "3.3.29",
-        "@microsoft/gulp-core-build-webpack": "3.4.96",
-        "@microsoft/load-themed-styles": "1.8.62",
-        "@microsoft/loader-cased-file": "1.8.2",
-        "@microsoft/loader-load-themed-styles": "1.7.127",
+        "@microsoft/gulp-core-build-serve": "3.3.39",
+        "@microsoft/gulp-core-build-webpack": "3.4.106",
+        "@microsoft/load-themed-styles": "1.9.7",
+        "@microsoft/loader-cased-file": "1.9.1",
+        "@microsoft/loader-load-themed-styles": "1.7.163",
         "@microsoft/node-core-library": "3.13.0",
-        "@microsoft/rush-lib": "5.5.2",
-        "@microsoft/set-webpack-public-path-plugin": "2.1.78",
-        "@microsoft/sp-module-interfaces": "1.8.2",
+        "@microsoft/rush-lib": "5.9.1",
+        "@microsoft/set-webpack-public-path-plugin": "2.1.113",
+        "@microsoft/sp-module-interfaces": "1.9.1",
         "@types/finalhandler": "0.0.31",
         "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.30",
@@ -1318,9 +980,11 @@
         "@types/resolve": "0.0.4",
         "@types/rimraf": "2.0.2",
         "@types/serve-static": "1.7.31",
+        "@types/terser-webpack-plugin": "1.2.1",
         "@types/uuid": "3.0.0",
         "@types/webpack": "4.4.0",
         "@types/webpack-stream": "3.2.10",
+        "@types/xml": "1.0.3",
         "azure-storage": "~2.8.2",
         "colors": "~1.2.1",
         "css-loader": "~0.28.7",
@@ -1341,17 +1005,18 @@
         "rimraf": "~2.6.1",
         "serve-static": "~1.10.2",
         "source-map-loader": "~0.2.4",
+        "terser-webpack-plugin": "1.2.3",
         "through2": "~2.0.1",
         "uuid": "~3.1.0",
-        "webpack": "~3.12.0",
-        "webpack-stream": "~4.0.0",
+        "webpack": "~4.31.0",
+        "webpack-stream": "~5.2.1",
         "xml": "~1.0.1"
       },
       "dependencies": {
         "@microsoft/load-themed-styles": {
-          "version": "1.8.62",
-          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.62.tgz",
-          "integrity": "sha512-T9yplfIBWV6R5n0y9TuAnF8og7lUTFRqiOD/F8y3J4ziAkg3RD2Gih7p0TdTD4vmqbFJOpuuXMNMpERFFMgvvg==",
+          "version": "1.9.7",
+          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.7.tgz",
+          "integrity": "sha512-8Iua4vPmffV2tT1nR/E55GSbUkYRPD9xFfa6v8zJ89EiiDrlyO2OGuXAtC6/nWxLTeVRA3GhtQuU2SApD2sQAA==",
           "dev": true
         },
         "@types/fs-extra": {
@@ -1458,6 +1123,31 @@
             "path-parse": "^1.0.5"
           }
         },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
         "send": {
           "version": "0.13.2",
           "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
@@ -1504,28 +1194,28 @@
       }
     },
     "@microsoft/sp-build-web": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.8.2.tgz",
-      "integrity": "sha512-icdm8kHrVqTh9tWZHvxVTnCzPRpkduHi73Bm31ADoBYfquqD5Q1+pqU5t9GOYWMoKFFkrQt4rmkMXf4B5VbPyQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.9.1.tgz",
+      "integrity": "sha512-JXQN8pzXWXeHeE8CU8cYgFb3hvwI7AQQfKHCBVfpkofkQ9Q7LT7Zzdtqz4QpukgrLfQ4S80C9cVnA8Tey7JFzw==",
       "dev": true,
       "requires": {
         "@microsoft/gulp-core-build": "3.9.26",
-        "@microsoft/gulp-core-build-sass": "4.6.2",
-        "@microsoft/gulp-core-build-serve": "3.3.29",
-        "@microsoft/gulp-core-build-typescript": "8.1.5",
-        "@microsoft/gulp-core-build-webpack": "3.4.96",
-        "@microsoft/sp-build-common": "1.8.2",
-        "@microsoft/sp-build-core-tasks": "1.8.2",
+        "@microsoft/gulp-core-build-sass": "4.7.3",
+        "@microsoft/gulp-core-build-serve": "3.3.39",
+        "@microsoft/gulp-core-build-typescript": "8.1.14",
+        "@microsoft/gulp-core-build-webpack": "3.4.106",
+        "@microsoft/sp-build-common": "1.9.1",
+        "@microsoft/sp-build-core-tasks": "1.9.1",
         "@types/webpack": "4.4.0",
         "gulp": "~3.9.1",
-        "webpack": "~3.12.0",
+        "webpack": "~4.31.0",
         "yargs": "~4.6.0"
       }
     },
     "@microsoft/sp-client-preview": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-client-preview/-/sp-client-preview-1.8.2.tgz",
-      "integrity": "sha512-4QEeRfYvDnrtdAShIHKMK3Dv5tHK34AqsRldV6lScb7WMNTOHQF74pPvWX+AO1vV4EqZYpyHukLdhLgZ/m+/xg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-client-preview/-/sp-client-preview-1.9.1.tgz",
+      "integrity": "sha512-HsDIf4u096mq/aned7gMVknIc/1i6WFK8VdwmUK4ftL1W1D3mXcYirOJJ/igTePSlNH575phdYz34Sf+BS7ksQ==",
       "dev": true,
       "requires": {
         "@types/webpack-env": "1.13.1",
@@ -1533,139 +1223,139 @@
       }
     },
     "@microsoft/sp-component-base": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.8.2.tgz",
-      "integrity": "sha512-8v7YOYgolyMuBzFrdMvLIalXTpBt4REvy//csoAsDudshjKI0trBDLcjaryjnshz33bzcLvaZArsfRXl3C4pEw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.9.1.tgz",
+      "integrity": "sha512-uCUaioBNQjZUuSPeFapGd5Yx3rUu7B7VzYzpFIF4Zp4ksgU+P9X41EsWV2j9nZuH9PjSea0wrdvuee/RmKnl2Q==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-dynamic-data": "1.8.2",
-        "@microsoft/sp-http": "1.8.2",
-        "@microsoft/sp-loader": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-page-context": "1.8.2",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-dynamic-data": "1.9.1",
+        "@microsoft/sp-http": "1.9.1",
+        "@microsoft/sp-loader": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-page-context": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
       }
     },
     "@microsoft/sp-core-library": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.8.2.tgz",
-      "integrity": "sha512-RW06oLu7sdMjq6vNtTFhvsQ7R7Ix5oJZqefC2J7p23yBWNNatmcwaBqM01SVdAsHd1coKwq3eU/0YMhzuaxKQw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.9.1.tgz",
+      "integrity": "sha512-mXmrZhyuA0NymTAC6HSUiMGFLni9OSlKfJGWKt02EyuFbQ3U4v4UnmvZgvnQZs9ZHBc7KrKInxRaYCjHrv2ITg==",
       "requires": {
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
       }
     },
     "@microsoft/sp-diagnostics": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.8.2.tgz",
-      "integrity": "sha512-l7qRUQduWG9waFgIP08E922PY+ea7xa2HZiEUDA6pdSOXbci2R9uo3fgL2Un5e63ZPKa5E1/0jtm1+xtgQkutA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.9.1.tgz",
+      "integrity": "sha512-Ggnszpej/zPfCeGCwzBg/pFvsNxq4/cGDc0J3cGQJknAv/5cldSefT6SqPDD7qELpXw/sTfq+Zy5pyGxQDvcVw==",
       "requires": {
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2"
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1"
       }
     },
     "@microsoft/sp-dialog": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-dialog/-/sp-dialog-1.8.2.tgz",
-      "integrity": "sha512-zLjJrv6/iQKM6jnXqTlDNF1hkqYJTsDodjVtNch36Qd1WhWc0gMSaotBQGFzgIfVm3bfm+m6pEUnJMXqLSZH9g==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-dialog/-/sp-dialog-1.9.1.tgz",
+      "integrity": "sha512-CLFnQROIei8TykyTGNg4QIVdXAi8CA8dr+GQM77b03EbrbazGuim1dOpowNgzc90+1ZcBkoVv9WKaqj9A0xINA==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-        "@microsoft/sp-application-base": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-webpart-base": "1.8.2",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/office-ui-fabric-react-bundle": "1.9.1",
+        "@microsoft/sp-application-base": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-webpart-base": "1.9.1",
         "@types/es6-promise": "0.0.33",
-        "@types/react": "16.4.2",
-        "@types/react-dom": "16.0.5",
+        "@types/react": "16.8.8",
+        "@types/react-dom": "16.8.3",
         "@types/webpack-env": "1.13.1",
-        "office-ui-fabric-react": "6.143.0",
-        "react": "16.7.0",
-        "react-dom": "16.7.0"
+        "office-ui-fabric-react": "6.189.2",
+        "react": "16.8.5",
+        "react-dom": "16.8.5"
       }
     },
     "@microsoft/sp-dynamic-data": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.8.2.tgz",
-      "integrity": "sha512-oC4220aH1ooU+VU9ADgnEeZ6YmWZfqvFaFG5vd2EL3jzTYiIxGLvBZOfDGKnsgmaDoWC7lXIYncoG0Os3rh/6w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.9.1.tgz",
+      "integrity": "sha512-NVHhesEQ/qUpJOr54SMJtIrRdVs+dJVT9eSo4ntsJF1N2o23FMvH7IHLym9e+tGK0XqA6c/f3SWq+ujVRDfLMQ==",
       "requires": {
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
         "@types/webpack-env": "1.13.1",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-extension-base": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.8.2.tgz",
-      "integrity": "sha512-kBoV6fIhM25ORZM5iA+HTiFX5jm5oLaue8nHnyYCFyATy14wSSG9i47OF3OxMsATY4qMaQ8W2YQIaWu3Sdnhvw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-extension-base/-/sp-extension-base-1.9.1.tgz",
+      "integrity": "sha512-OQgf3nP3DsbmdqGquy2U2xT8pHXX6l6QVhPIeqo4z9a+cpr9tviHK6XwQWe6/JDlJIhJqC2W2XPtCyF4Ka64rw==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/sp-component-base": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-http": "1.8.2",
-        "@microsoft/sp-loader": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-page-context": "1.8.2",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/sp-component-base": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-http": "1.9.1",
+        "@microsoft/sp-loader": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-page-context": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1"
       }
     },
     "@microsoft/sp-http": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.8.2.tgz",
-      "integrity": "sha512-lTVQ6oI1yjc4M0yeyQHrivy+6SNp1q4xUQ3skBWY25b55zPIJHH3m/nOvHy2q44b9eWurdjq7bS1T19lrf7+LQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.9.1.tgz",
+      "integrity": "sha512-bNV1BsWbadyY+xOpeQNiS8P0mYCLYd65ULL/lt+bzv8ZhlKC7/E5TXW2d2IBYcBNT0cUNEsHf7hEfv787bbWtA==",
       "requires": {
         "@microsoft/microsoft-graph-client": "~1.1.0",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
         "@types/adal-angular": "1.0.1",
         "adal-angular": "1.0.16",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-loader": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.8.2.tgz",
-      "integrity": "sha512-Q1LKFV8jOqWV6451dpDFwyaMK2Hw4X+tcnX5hFqltL1O1r/rD2P7PJkLi8lpL8sqWJ9JhTDDY8+pWD1YYC6W6A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.9.1.tgz",
+      "integrity": "sha512-UzeKD+26ciLVcoawUB9ELuwhzDC2LRG6dHGtlq6ys7qANkNla5cfUBksWwjctCI7jF/wwdylrzlzcfZc6TOlmQ==",
       "requires": {
-        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-dynamic-data": "1.8.2",
-        "@microsoft/sp-http": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-odata-types": "1.8.2",
-        "@microsoft/sp-page-context": "1.8.2",
-        "@microsoft/sp-polyfills": "1.8.2",
+        "@microsoft/office-ui-fabric-react-bundle": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-dynamic-data": "1.9.1",
+        "@microsoft/sp-http": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-odata-types": "1.9.1",
+        "@microsoft/sp-page-context": "1.9.1",
+        "@microsoft/sp-polyfills": "1.9.1",
         "@types/es6-promise": "0.0.33",
-        "@types/node": "8.5.8",
-        "@types/react": "16.4.2",
-        "@types/react-dom": "16.0.5",
+        "@types/react": "16.8.8",
+        "@types/react-dom": "16.8.3",
         "@types/requirejs": "2.1.29",
         "@types/webpack-env": "1.13.1",
-        "@uifabric/utilities": "6.29.4",
-        "office-ui-fabric-react": "6.143.0",
-        "react": "16.7.0",
-        "react-dom": "16.7.0",
+        "@uifabric/utilities": "6.41.3",
+        "office-ui-fabric-react": "6.189.2",
+        "react": "16.8.5",
+        "react-dom": "16.8.5",
         "requirejs": "2.1.20",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-lodash-subset": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.8.2.tgz",
-      "integrity": "sha512-PTJuBAqqgxJ6xo8OQWS4sTPOyzgXzPyT60BTHyZJd8ozDoeo3lrTssmXgOaAygMUE+VglyoH7YRNAv+fg/tOgQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.9.1.tgz",
+      "integrity": "sha512-bHYp2vyKfB/TYmCClUw9SCvJ7EYGeJOx8bxIm1hBlYzNBtIQvotTfdFBNz6vYEAXczMQHZkO9vToEd5jSturEA==",
       "requires": {
         "@types/lodash": "4.14.117",
         "@types/webpack-env": "1.13.1",
@@ -1673,9 +1363,9 @@
       }
     },
     "@microsoft/sp-module-interfaces": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.8.2.tgz",
-      "integrity": "sha512-vuwmEHZ1dP9Q5/irqpTJynkHmyxP2vfn05Bdehzd/ktlvf4CtUjgVIRXuOCPufGe5fvr96IMKLlhOzifS5sUBw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.9.1.tgz",
+      "integrity": "sha512-c9ihRbxq3zOv1hU76BNFlB1i2ZOTidgPmoz5BRHogSarcTC6NxnB+4pP8ulSvvV5NiNZLFZrNNF5WXg1wbGIqA==",
       "requires": {
         "@types/node": "8.5.8",
         "@types/z-schema": "3.16.31",
@@ -1683,32 +1373,32 @@
       }
     },
     "@microsoft/sp-odata-types": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.8.2.tgz",
-      "integrity": "sha512-reRLI23NHfUwJAcQmTGl3z80ncqRlW6YSs8OoZFkIEsYsnuv7P+xwJnhH+4im8ywJ+3ESEOZj6ZtdrvUM9PcmA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.9.1.tgz",
+      "integrity": "sha512-Gy3Ke4MQv1gQxhAlAgp9aWZ9R3nCKr7uZ67186BZit0sSqFmmv3XWGUMS3DCKQo3+piQWCoZPU8XvmyBmAo9+w==",
       "requires": {
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-page-context": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.8.2.tgz",
-      "integrity": "sha512-TkVV/h5XEJUfGH/80y0YPD3jWEli8V3Z+Xsnub0ZjC5lU492J1JLFDeNMqIlG25vhIeL+V+Le9hxU9cTNW4hsA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.9.1.tgz",
+      "integrity": "sha512-eFFbUxcGhjtS4CD57fzphNDqRgLbY2SHY9zsjfDYRiiAqOxrKGC2XklLbS6zCEb4xXOCZAPyPDHYmR8tLRAE2g==",
       "requires": {
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-dynamic-data": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-odata-types": "1.8.2",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-dynamic-data": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-odata-types": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-polyfills": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.8.2.tgz",
-      "integrity": "sha512-0Zl7ipeFws2PJYbtVQ0UMWzBExZuH5qQZuzf25KXmYsQd8tgMNBI3C1OCnTqbTYVx8LhdJtlf5y5D1mYLV4Raw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.9.1.tgz",
+      "integrity": "sha512-SnMa/afIKvHnHIEkokM6MO0EGqmKBWs+7L2KRumkwUCtfFOue5fDL+FDfoDMMt+EN9nVbVXuEwn6ZJhgizhPrA==",
       "requires": {
         "@types/webpack-env": "1.13.1",
         "es6-collections": "0.5.6",
@@ -1731,31 +1421,31 @@
       }
     },
     "@microsoft/sp-property-pane": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.8.2.tgz",
-      "integrity": "sha512-XGHxlx4vyQIA9TeeYB38OQcHQ+ehn/SWVMS6HM+hJmjdCRWFjHIpCYamvuWyrL8hkOFLvvv7w8mPt23aLjSTag==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.9.1.tgz",
+      "integrity": "sha512-dfGAGXJzm/Ra6jJAbO06sgmsI7oohyACDeU65Eh97eZffLRbUsSw7AnQnkG/NK+FHmVLQLH+c8DXzOYfEwAJrA==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-        "@microsoft/sp-component-base": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-dynamic-data": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/office-ui-fabric-react-bundle": "1.9.1",
+        "@microsoft/sp-component-base": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-dynamic-data": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
         "@types/es6-promise": "0.0.33",
-        "@types/react": "16.4.2",
-        "@types/react-dom": "16.0.5",
+        "@types/react": "16.8.8",
+        "@types/react-dom": "16.8.3",
         "@types/webpack-env": "1.13.1",
-        "office-ui-fabric-react": "6.143.0",
-        "react": "16.7.0",
-        "react-dom": "16.7.0",
+        "office-ui-fabric-react": "6.189.2",
+        "react": "16.8.5",
+        "react-dom": "16.8.5",
         "tslib": "~1.9.3"
       }
     },
     "@microsoft/sp-tslint-rules": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-tslint-rules/-/sp-tslint-rules-1.8.2.tgz",
-      "integrity": "sha512-GYvZYBmrlfQpqVG5fELU2rMK+ucxzBA/aaZVzMhxEwMaSi/vgtiZ+vDb/SmigalPQ+JKP3DQJ0si3xkIiD3ayQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-tslint-rules/-/sp-tslint-rules-1.9.1.tgz",
+      "integrity": "sha512-pCavxBaurrp7KSrs9Fcr3im3VyAYfPi+bY3cQ6CnlsEUwAE04LGgnAhYadHhOBcsQrc4nhWOwXj1L4QzDIX5hA==",
       "dev": true,
       "requires": {
         "tslint": "~5.9.1",
@@ -1806,65 +1496,65 @@
       }
     },
     "@microsoft/sp-webpart-base": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.8.2.tgz",
-      "integrity": "sha512-6dj0pd1iNHsxyRG4+ORyItVd/lqbSuXi473kO2nuOzdHW+LqWwriXq5qaWq2tJ9eEJRu9J+ONqhU4rEL99GdMg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.9.1.tgz",
+      "integrity": "sha512-oqisT6MMrz5YmaUdFYSkqJMOoh0RdOOFU+xG2+iCSFfkOHg8FaQtHJM4sSCn5/wMDIcFIB7cEiG7hSRbVrwHtw==",
       "requires": {
-        "@microsoft/decorators": "1.8.2",
-        "@microsoft/load-themed-styles": "1.8.62",
-        "@microsoft/sp-component-base": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-diagnostics": "1.8.2",
-        "@microsoft/sp-dynamic-data": "1.8.2",
-        "@microsoft/sp-http": "1.8.2",
-        "@microsoft/sp-loader": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-page-context": "1.8.2",
-        "@microsoft/sp-property-pane": "1.8.2",
-        "@microsoft/teams-js": "1.4.1",
+        "@microsoft/decorators": "1.9.1",
+        "@microsoft/load-themed-styles": "1.9.7",
+        "@microsoft/sp-component-base": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-diagnostics": "1.9.1",
+        "@microsoft/sp-dynamic-data": "1.9.1",
+        "@microsoft/sp-http": "1.9.1",
+        "@microsoft/sp-loader": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-page-context": "1.9.1",
+        "@microsoft/sp-property-pane": "1.9.1",
+        "@microsoft/teams-js": "1.4.2",
         "@types/es6-promise": "0.0.33",
         "@types/webpack-env": "1.13.1",
-        "office-ui-fabric-react": "6.143.0",
+        "office-ui-fabric-react": "6.189.2",
         "tslib": "~1.9.3"
       },
       "dependencies": {
         "@microsoft/load-themed-styles": {
-          "version": "1.8.62",
-          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.62.tgz",
-          "integrity": "sha512-T9yplfIBWV6R5n0y9TuAnF8og7lUTFRqiOD/F8y3J4ziAkg3RD2Gih7p0TdTD4vmqbFJOpuuXMNMpERFFMgvvg=="
+          "version": "1.9.7",
+          "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.9.7.tgz",
+          "integrity": "sha512-8Iua4vPmffV2tT1nR/E55GSbUkYRPD9xFfa6v8zJ89EiiDrlyO2OGuXAtC6/nWxLTeVRA3GhtQuU2SApD2sQAA=="
         }
       }
     },
     "@microsoft/sp-webpart-workbench": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-workbench/-/sp-webpart-workbench-1.8.2.tgz",
-      "integrity": "sha512-+GKibJjmgdkguG2eKNIDIxyIj4BQpJtpROkAF4+r6Uoe1jOeDhdjtMEaVyZD26jITNXT9wK11ZmLkIsJOFR/sw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-workbench/-/sp-webpart-workbench-1.9.1.tgz",
+      "integrity": "sha512-SWQNa0ID24NHVWendU1HthY1g8bMMEQyDrgtpLLzEcK0itARufSaPBbvnuhDUHDISv8Yy7pmdC5ggqD8FCwS9A==",
       "dev": true,
       "requires": {
-        "@microsoft/gulp-core-build-serve": "3.3.29",
+        "@microsoft/gulp-core-build-serve": "3.3.39",
         "@microsoft/node-core-library": "3.13.0",
-        "@microsoft/office-ui-fabric-react-bundle": "1.8.2",
-        "@microsoft/sp-application-base": "1.8.2",
-        "@microsoft/sp-build-core-tasks": "1.8.2",
-        "@microsoft/sp-client-preview": "1.8.2",
-        "@microsoft/sp-core-library": "1.8.2",
-        "@microsoft/sp-loader": "1.8.2",
-        "@microsoft/sp-lodash-subset": "1.8.2",
-        "@microsoft/sp-module-interfaces": "1.8.2",
-        "@microsoft/sp-property-pane": "1.8.2",
-        "@microsoft/sp-webpart-base": "1.8.2",
+        "@microsoft/office-ui-fabric-react-bundle": "1.9.1",
+        "@microsoft/sp-application-base": "1.9.1",
+        "@microsoft/sp-build-core-tasks": "1.9.1",
+        "@microsoft/sp-client-preview": "1.9.1",
+        "@microsoft/sp-core-library": "1.9.1",
+        "@microsoft/sp-loader": "1.9.1",
+        "@microsoft/sp-lodash-subset": "1.9.1",
+        "@microsoft/sp-module-interfaces": "1.9.1",
+        "@microsoft/sp-property-pane": "1.9.1",
+        "@microsoft/sp-webpart-base": "1.9.1",
         "@types/es6-promise": "0.0.33",
         "@types/fs-extra": "5.0.1",
-        "@types/react": "16.4.2",
-        "@types/react-dom": "16.0.5",
+        "@types/react": "16.8.8",
+        "@types/react-dom": "16.8.3",
         "@types/webpack-env": "1.13.1",
-        "@uifabric/variants": "6.14.0",
+        "@uifabric/variants": "6.14.2",
         "fs-extra": "~5.0.0",
-        "office-ui-fabric-react": "6.143.0",
+        "office-ui-fabric-react": "6.189.2",
         "prop-types": "15.6.0",
-        "react": "16.7.0",
-        "react-dom": "16.7.0",
+        "react": "16.8.5",
+        "react-dom": "16.8.5",
         "tslib": "~1.9.3"
       },
       "dependencies": {
@@ -1902,9 +1592,9 @@
       }
     },
     "@microsoft/stream-collator": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@microsoft/stream-collator/-/stream-collator-3.0.15.tgz",
-      "integrity": "sha512-c/xc6A4E3OUcFAMnIdq1AxjdxsPj1DFDTgsdVbiNAZTP7Hx7dGGQ+I8w8e6AfrL7SYaNwqMdrGHIzrvXmEZDGA==",
+      "version": "3.0.73",
+      "resolved": "https://registry.npmjs.org/@microsoft/stream-collator/-/stream-collator-3.0.73.tgz",
+      "integrity": "sha512-WAvVio4ipsp6BX6Ssm/fNbM6x2FKvencxqOHhbqHumNPdWqwK3gqYaDAgD6klabhKbnSLuG4zySKD97cn/F/xA==",
       "dev": true,
       "requires": {
         "@types/node": "8.5.8",
@@ -1912,14 +1602,14 @@
       }
     },
     "@microsoft/teams-js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.4.1.tgz",
-      "integrity": "sha512-0BuWgUrZvZ0X98roHTWQVtnjlw22DWJBFW7LCqKS7Q/0Zu19GAWNL/mJoVJRRujVHUbEW+QU0qwJK6KqitUcsw=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.4.2.tgz",
+      "integrity": "sha512-O10tpakpm+NyClJOW4eCaidlDI5sW9b5oRGQiUA0WqFG6GQt1HEz/KFsCN+ebaFgjstx+trZzYIuYdpK98XsMQ=="
     },
     "@microsoft/ts-command-line": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.3.tgz",
-      "integrity": "sha512-SIs4q7RcG7efBbh5Ffrf6V4jVLxWihD4NDRY3+gPiOG8CYawBzE22tTEloZ1yj/FBvBZQkQ0GYwXoPhn6ElYXA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.5.tgz",
+      "integrity": "sha512-QyTfbfpx6o+1cnjx5GubqKSRMDxBBMXABSa8wmqRa/A1K99FEBZfLIO6GmaY0s7rNYEchfR1VcVS/hV2VW+6hw==",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.33",
@@ -1957,9 +1647,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
-          "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
+          "version": "10.14.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
+          "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==",
           "dev": true
         },
         "normalize-path": {
@@ -1982,9 +1672,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
-          "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
+          "version": "10.14.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
+          "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA==",
           "dev": true
         }
       }
@@ -2042,9 +1732,9 @@
       "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw=="
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
-      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+      "version": "4.16.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
+      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2179,6 +1869,11 @@
         "@types/q": "*"
       }
     },
+    "@types/prop-types": {
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+    },
     "@types/q": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
@@ -2198,19 +1893,19 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.2.tgz",
-      "integrity": "sha512-oVcVteCDNiVc/fkDjowRfAZQDEOR76j3CJ3FvwXNvfV6zJguhghy1lMgpAzYox+9AZsWch+JPV6Imml3wvIUeg==",
+      "version": "16.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.8.tgz",
+      "integrity": "sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==",
       "requires": {
+        "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
     },
     "@types/react-dom": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.5.tgz",
-      "integrity": "sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==",
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.3.tgz",
+      "integrity": "sha512-HF5hD5YR3z9Mn6kXcW1VKe4AQ04ZlZj1EdLBae61hzQ3eEWWxMgNLUbIxeZp40BnSxqY1eAYLsH9QopQcxzScA==",
       "requires": {
-        "@types/node": "*",
         "@types/react": "*"
       }
     },
@@ -2386,6 +2081,16 @@
       "integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==",
       "dev": true
     },
+    "@types/terser-webpack-plugin": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
+      "integrity": "sha512-5mzQulZabFsqiLh0PhJdccIKqpd5535UYpZ+Skugz8kPzZdajMMYBRKQSzM1KOkZ42NwLxbZSzQp6xKtaq46Gg==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "*",
+        "terser": "^3.16.1"
+      }
+    },
     "@types/through": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
@@ -2458,6 +2163,15 @@
         "@types/webpack": "*"
       }
     },
+    "@types/xml": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/xml/-/xml-1.0.3.tgz",
+      "integrity": "sha512-qeqQIjDfSLjmWR0noFQmcPKCtqn0L68MchoEi1Zj33unPfC83Op3j2mBH2g4hAgOaWUobv/O86w7LObo6p4sDQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-0.0.34.tgz",
@@ -2470,36 +2184,23 @@
       "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
     },
     "@uifabric/foundation": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-0.8.2.tgz",
-      "integrity": "sha512-OW6Hk872MLMCRQkuzDzw4R786IrMw1PJflyxOjVleiGNxNckdiZgLbwD5kujCj9cVLex9XydYXC3m2+y+4FcDw==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-0.7.7.tgz",
+      "integrity": "sha512-ZsX6vuPX6OpvUb26GL7ribJELYt2SOKFhuM4W+YcowPSBTRLl2DSC+ZkaLI4VngT//D89tl0SqmipukcSn4hDA==",
       "requires": {
         "@uifabric/set-version": "^1.1.3",
-        "@uifabric/styling": "^6.50.3",
-        "@uifabric/utilities": "^6.41.6",
+        "@uifabric/styling": "^6.48.1",
+        "@uifabric/utilities": "^6.41.0",
         "tslib": "^1.7.1"
-      },
-      "dependencies": {
-        "@uifabric/utilities": {
-          "version": "6.41.6",
-          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.41.6.tgz",
-          "integrity": "sha512-xD2/Jy8OMACZSyRoN3dwk3Ds9QcU4jkf9GDc5mJcSqCyYp3ShlO6ggx4u28OFB5qhsIljtzop31hTvL6PH23Cg==",
-          "requires": {
-            "@uifabric/merge-styles": "^6.19.3",
-            "@uifabric/set-version": "^1.1.3",
-            "prop-types": "^15.5.10",
-            "tslib": "^1.7.1"
-          }
-        }
       }
     },
     "@uifabric/icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.4.0.tgz",
-      "integrity": "sha512-pbKu3OnWaRIeDqMFhicDrrcqicxNqoHpJpknZR9N2xxoPnYMnt2ZOhBNnAxoVVcxHlWkFNg0rvFrOAQGn+S5/Q==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.5.3.tgz",
+      "integrity": "sha512-baqA8QGP68RD2IsKfsd40hVK1/GyweOvAKYcxkCIFXGz0mGtBVhSy8hs1jHdU9cdZeo4ebDkkn11TizCm/b00A==",
       "requires": {
-        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-        "@uifabric/styling": ">=6.41.0 <7.0.0",
+        "@uifabric/set-version": "^1.1.3",
+        "@uifabric/styling": "^6.49.1",
         "tslib": "^1.7.1"
       }
     },
@@ -2521,9 +2222,9 @@
       }
     },
     "@uifabric/styling": {
-      "version": "6.50.3",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.3.tgz",
-      "integrity": "sha512-k7ZIInlUz+oIaD1cXZi2a6s3Ms3VjIqdt7A9oT/SlTSrGcec5punjiUajETUgHpOlp39ZTTqB91Qeqrk9yA9Gg==",
+      "version": "6.50.6",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.50.6.tgz",
+      "integrity": "sha512-v5XfP9IJQPH4Rxn6aHo9hvFQK0BNneGWZoqTsUDvuBn+3JJITdPjYIh/jOjUrJk50p2i9L3iFs4ybtcrqtKPGg==",
       "requires": {
         "@microsoft/load-themed-styles": "^1.7.13",
         "@uifabric/merge-styles": "^6.19.3",
@@ -2546,26 +2247,214 @@
       }
     },
     "@uifabric/utilities": {
-      "version": "6.29.4",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.29.4.tgz",
-      "integrity": "sha512-ESyMQfJrIGy1uM0HQApW0gvKpQCZBWLLoQTGZIq8Z4ZcTUEYN4Te+6oImtn0dxI1CIK6fbQNtLvZb5fX82+jMA==",
+      "version": "6.41.3",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.41.3.tgz",
+      "integrity": "sha512-gO+bdJQMMwFz4jnOJnkcaFIKrg8KT+EKYaynoqo0Q1N/Fw4QYLo5tUNxwIkOhI6tPo3zo/TIxIYJn+yt3la9ZQ==",
       "requires": {
-        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-        "@uifabric/set-version": ">=1.1.3 <2.0.0",
+        "@uifabric/merge-styles": "^6.19.2",
+        "@uifabric/set-version": "^1.1.3",
         "prop-types": "^15.5.10",
         "tslib": "^1.7.1"
       }
     },
     "@uifabric/variants": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-6.14.0.tgz",
-      "integrity": "sha512-RZyGrkl9gWvp9n0/+4j6yif9GdqP0WI5izjhMtWG7b+pNyJIVasP8fjtFZrjQj6WHaYlOMfSgnjbi1mjkZA8hg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/variants/-/variants-6.14.2.tgz",
+      "integrity": "sha512-TTr2CbhCGB1ycAgC9EazRJWxJgLR2/ikPvoEc4FhZ1Cc8MezaSTz2+RVpm7fCIvUOVtC0JU0RAyqNArGQDr7QA==",
       "dev": true,
       "requires": {
-        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-        "office-ui-fabric-react": ">=6.110.1 <7.0.0",
+        "@uifabric/set-version": "^1.1.3",
+        "office-ui-fabric-react": "^6.181.1",
         "tslib": "^1.7.1"
       }
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "^0.0.3"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
     },
     "@yarnpkg/lockfile": {
       "version": "1.0.2",
@@ -2630,9 +2519,9 @@
       }
     },
     "acorn-globals": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-      "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -2640,9 +2529,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         }
       }
@@ -2692,6 +2581,12 @@
           "dev": true
         }
       }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
@@ -3043,9 +2938,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "asynckit": {
@@ -3444,9 +3339,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "batch": {
@@ -3502,6 +3397,12 @@
       "requires": {
         "inherits": "~2.0.0"
       }
+    },
+    "bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -3768,6 +3669,51 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cacache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+      "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -3850,15 +3796,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000986",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000986.tgz",
-      "integrity": "sha512-8SKJ12AFwG0ReMjPwRH+keFsX/ucw2bi6LC7upeXBvxjgrMqHaTxgYhkRGm+eOwUWvVcqXDgqM7QNlRJMhvXZg==",
+      "version": "1.0.30000989",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000989.tgz",
+      "integrity": "sha512-5pkU/t9nueoBgELZOCpK+wN4wK6MkIz1Q9lGZSgLwg4xR8EhLY9r0qj6T2bUI8Cq9pGbioEar+Zqgosk5fpbjg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000986",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000986.tgz",
-      "integrity": "sha512-pM+LnkoAX0+QnIH3tpW5EnkmfpEoqOD8FAcoBvsl3Xh6DXkgctiCxeCbXphP/k3XJtJzm+zOAJbi6U6IVkpWZQ==",
+      "version": "1.0.30000989",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
       "dev": true
     },
     "capture-exit": {
@@ -3924,9 +3870,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -3986,6 +3932,15 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
       "dev": true
+    },
+    "chrome-trace-event": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "ci-info": {
       "version": "1.6.0",
@@ -4266,6 +4221,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -4277,6 +4238,50 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "connect": {
       "version": "3.7.0",
@@ -4372,6 +4377,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -4896,6 +4915,12 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -5311,9 +5336,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.203",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.203.tgz",
-      "integrity": "sha512-Z1FjJKEBhYrCNmnususVk8khiBabVI/bSJB/295V4ghVt4MFmtbP+mXgRZLQZinEBI469U6FtiGgpXnlLs6qiQ==",
+      "version": "1.3.241",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.241.tgz",
+      "integrity": "sha512-Gb9E6nWZlbgjDDNe5cAvMJixtn79krNJ70EDpq/M10lkGo7PGtBUe7Y0CYVHsBScRwi6ybCS+YetXAN9ysAHDg==",
       "dev": true
     },
     "elliptic": {
@@ -5539,9 +5564,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -5571,6 +5596,16 @@
         "estraverse": "^4.1.1"
       }
     },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5587,15 +5622,15 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "etag": {
@@ -6031,6 +6066,12 @@
         }
       }
     },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -6132,6 +6173,71 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
+      }
+    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
@@ -6189,6 +6295,48 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -6255,6 +6403,48 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6273,6 +6463,18 @@
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -6937,9 +7139,9 @@
       }
     },
     "git-repo-info": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.4.tgz",
-      "integrity": "sha1-E0n6OIinZh6h/2OgR8L/Q7PglgI=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.0.tgz",
+      "integrity": "sha512-+kigfDB7j3W80f74BoOUX+lKOmf4pR3/i2Ww6baKTCPe2hD4FRdjhV3s4P5Dy0Tak1uY1891QhKoYNtnyX2VvA==",
       "dev": true
     },
     "glob": {
@@ -7198,9 +7400,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
     "growly": {
@@ -7673,9 +7875,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
     },
     "html-comment-regex": {
@@ -7894,6 +8096,12 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "import-local": {
@@ -8976,9 +9184,9 @@
           }
         },
         "node-notifier": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-          "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
           "dev": true,
           "requires": {
             "growly": "^1.3.0",
@@ -8999,9 +9207,9 @@
           }
         },
         "source-map-support": {
-          "version": "0.5.12",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -9677,9 +9885,9 @@
       },
       "dependencies": {
         "source-map-support": {
-          "version": "0.5.12",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -10526,6 +10734,24 @@
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -10543,6 +10769,12 @@
       "requires": {
         "tmpl": "1.0.x"
       }
+    },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -10820,9 +11052,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.4.0.tgz",
+      "integrity": "sha512-6PmOuSP4NnZXzs2z6rbwzLJu/c5gdzYg1mRI/WIYdx45iiX7T+a4esOzavD6V/KmBzAaopFSTZPZcUx73bqKWA==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
@@ -10844,6 +11076,24 @@
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
+      }
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -10891,6 +11141,20 @@
       "dev": true,
       "requires": {
         "mkdirp": "*"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -11126,12 +11390,20 @@
           }
         },
         "string_decoder": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+              "dev": true
+            }
           }
         }
       }
@@ -11149,9 +11421,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.26",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-      "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz",
+      "integrity": "sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -11329,9 +11601,9 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -11537,17 +11809,17 @@
       }
     },
     "office-ui-fabric-react": {
-      "version": "6.143.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.143.0.tgz",
-      "integrity": "sha512-JXV1h8upR+WPYQ7SuJFgp9XuLrJUDT9QjI7bzbyY+dpwjKCX0D22BlTfi7O52IdDt4eFesJofN8DfW0A/opvMw==",
+      "version": "6.189.2",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.189.2.tgz",
+      "integrity": "sha512-1Y111Ip78u7aCbmyRTucRldY4lYwRPkxhFL+y1rgQC4TivB2FmoHN6eSA1nAA59Ix4k2etM0UCzh7MdC1SbP5Q==",
       "requires": {
         "@microsoft/load-themed-styles": "^1.7.13",
-        "@uifabric/foundation": ">=0.7.1 <1.0.0",
-        "@uifabric/icons": ">=6.4.0 <7.0.0",
-        "@uifabric/merge-styles": ">=6.15.2 <7.0.0",
-        "@uifabric/set-version": ">=1.1.3 <2.0.0",
-        "@uifabric/styling": ">=6.41.0 <7.0.0",
-        "@uifabric/utilities": ">=6.29.3 <7.0.0",
+        "@uifabric/foundation": "^0.7.6",
+        "@uifabric/icons": "^6.5.2",
+        "@uifabric/merge-styles": "^6.18.0",
+        "@uifabric/set-version": "^1.1.3",
+        "@uifabric/styling": "^6.48.0",
+        "@uifabric/utilities": "^6.40.1",
         "prop-types": "^15.5.10",
         "tslib": "^1.7.1"
       }
@@ -11754,6 +12026,49 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
       "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "param-case": {
       "version": "2.1.1",
@@ -14020,6 +14335,12 @@
         "asap": "~2.0.3"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
     "prompts": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
@@ -14063,9 +14384,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
       "dev": true
     },
     "public-encrypt": {
@@ -14080,6 +14401,39 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "punycode": {
@@ -14204,31 +14558,31 @@
       }
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+      "integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.5"
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.5.tgz",
+      "integrity": "sha512-VIEIvZLpFafsfu4kgmftP5L8j7P1f0YThfVTrANMhZUFMDOsA6e0kfR6wxw/8xxKs4NB59TZYbxNdPCDW34x4w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.5"
       }
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "read": {
       "version": "1.0.7",
@@ -14240,9 +14594,9 @@
       }
     },
     "read-package-json": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-      "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.0.tgz",
+      "integrity": "sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==",
       "dev": true,
       "requires": {
         "glob": "^7.1.1",
@@ -14760,9 +15114,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -14791,6 +15145,15 @@
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -14942,9 +15305,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -14996,9 +15359,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "send": {
@@ -15026,6 +15389,12 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
+      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
       "dev": true
     },
     "serve-index": {
@@ -15447,6 +15816,15 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -15584,6 +15962,16 @@
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
       "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
     },
     "stream-http": {
       "version": "2.8.3",
@@ -15839,6 +16227,70 @@
         "through2": "^2.0.1"
       }
     },
+    "terser": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+      "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
+      "dev": true,
+      "requires": {
+        "cacache": "^11.0.2",
+        "find-cache-dir": "^2.0.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "terser": "^3.16.1",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
@@ -16037,9 +16489,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -16330,9 +16782,9 @@
       "dev": true
     },
     "type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
       "dev": true
     },
     "type-check": {
@@ -16353,6 +16805,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "2.9.2",
@@ -16490,6 +16948,24 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
     },
     "unique-stream": {
       "version": "1.0.0",
@@ -16652,9 +17128,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "v8flags": {
@@ -16863,35 +17339,49 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "webpack": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
-      "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.31.0.tgz",
+      "integrity": "sha512-n6RVO3X0LbbipoE62akME9K/JI7qYrwwufs20VvgNNpqUoH4860KkaxJTbGq5bgkVZF9FqyyTG/0WPLH3PVNJA==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.0.5",
+        "acorn-dynamic-import": "^4.0.0",
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.4.0",
-        "escope": "^3.6.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
+        "chrome-trace-event": "^1.0.0",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.0",
+        "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^2.3.0",
         "loader-utils": "^1.1.0",
         "memory-fs": "~0.4.1",
+        "micromatch": "^3.1.8",
         "mkdirp": "~0.5.0",
+        "neo-async": "^2.5.0",
         "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^4.2.1",
-        "tapable": "^0.2.7",
-        "uglifyjs-webpack-plugin": "^0.4.6",
-        "watchpack": "^1.4.0",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^8.0.2"
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.0",
+        "terser-webpack-plugin": "^1.1.0",
+        "watchpack": "^1.5.0",
+        "webpack-sources": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
+        "acorn-dynamic-import": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+          "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+          "dev": true
+        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -16910,55 +17400,24 @@
           "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
           "dev": true
         },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+          "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
@@ -16970,106 +17429,31 @@
             "big.js": "^5.2.2",
             "emojis-list": "^2.0.0",
             "json5": "^1.0.1"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-              "dev": true,
-              "requires": {
-                "minimist": "^1.2.0"
-              }
-            }
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
         }
       }
     },
     "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
@@ -17077,20 +17461,20 @@
       }
     },
     "webpack-stream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-4.0.3.tgz",
-      "integrity": "sha512-Tx7ks7Of/JiPz7/tUM4WqSg4OcXF4m4OzNSaEzNA1TNXQaiTHIjiKqUoL79wGXbFt2q1IP8VG5DcEdaxifY5Ew==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-5.2.1.tgz",
+      "integrity": "sha512-WvyVU0K1/VB1NZ7JfsaemVdG0PXAQUqbjUNW4A58th4pULvKMQxG+y33HXTL02JvD56ko2Cub+E2NyPwrLBT/A==",
       "dev": true,
       "requires": {
-        "fancy-log": "^1.3.2",
+        "fancy-log": "^1.3.3",
         "lodash.clone": "^4.3.2",
         "lodash.some": "^4.2.2",
         "memory-fs": "^0.4.1",
         "plugin-error": "^1.0.1",
-        "supports-color": "^5.3.0",
+        "supports-color": "^5.5.0",
         "through": "^2.3.8",
         "vinyl": "^2.1.0",
-        "webpack": "^3.4.1"
+        "webpack": "^4.26.1"
       },
       "dependencies": {
         "supports-color": {
@@ -17191,6 +17575,15 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
+    },
+    "worker-farm": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.7"
+      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/samples/js-application-appinsights/package.json
+++ b/samples/js-application-appinsights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-insights",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "engines": {
     "node": ">=0.10.0"
@@ -11,19 +11,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "@microsoft/sp-core-library": "1.8.2",
-    "@microsoft/decorators": "1.8.2",
-    "@types/webpack-env": "1.13.1",
+    "@microsoft/decorators": "1.9.1",
+    "@microsoft/sp-application-base": "1.9.1",
+    "@microsoft/sp-core-library": "1.9.1",
+    "@microsoft/sp-dialog": "1.9.1",
     "@types/es6-promise": "0.0.33",
-    "@microsoft/sp-dialog": "1.8.2",
-    "@microsoft/sp-application-base": "1.8.2"
+    "@types/webpack-env": "1.13.1"
   },
   "devDependencies": {
-    "@microsoft/sp-build-web": "1.8.2",
-    "@microsoft/sp-tslint-rules": "1.8.2",
-    "@microsoft/sp-module-interfaces": "1.8.2",
-    "@microsoft/sp-webpart-workbench": "1.8.2",
-    "@microsoft/rush-stack-compiler-2.9": "0.7.7",
+    "@microsoft/sp-build-web": "1.9.1",
+    "@microsoft/sp-tslint-rules": "1.9.1",
+    "@microsoft/sp-module-interfaces": "1.9.1",
+    "@microsoft/sp-webpart-workbench": "1.9.1",
+    "@microsoft/rush-stack-compiler-2.9": "0.7.16",
     "gulp": "~3.9.1",
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",

--- a/samples/js-application-appinsights/sharepoint/assets/ClientSideInstance.xml
+++ b/samples/js-application-appinsights/sharepoint/assets/ClientSideInstance.xml
@@ -4,6 +4,6 @@
         Title="AppInsights"
         Location="ClientSideExtension.ApplicationCustomizer"
         ComponentId="5e627b50-6e2b-418e-96c9-14f4a8e0507c"
-        Properties="">
+        Properties="{&quot;appInsightsKey&quot;:&quot;a09f32d3-479e-4782-b6db-1bdce04536db&quot;}">
     </ClientSideComponentInstance>
 </Elements>

--- a/samples/js-application-appinsights/sharepoint/assets/elements.xml
+++ b/samples/js-application-appinsights/sharepoint/assets/elements.xml
@@ -4,6 +4,6 @@
         Title="AppInsights"
         Location="ClientSideExtension.ApplicationCustomizer"
         ClientSideComponentId="5e627b50-6e2b-418e-96c9-14f4a8e0507c"
-        ClientSideComponentProperties="">
+        ClientSideComponentProperties="{&quot;appInsightsKey&quot;:&quot;a09f32d3-479e-4782-b6db-1bdce04536db&quot;}">
     </CustomAction>
 </Elements>

--- a/samples/js-application-appinsights/src/extensions/appInsights/AppInsightsApplicationCustomizer.ts
+++ b/samples/js-application-appinsights/src/extensions/appInsights/AppInsightsApplicationCustomizer.ts
@@ -10,10 +10,9 @@ import * as strings from 'AppInsightsApplicationCustomizerStrings';
 const LOG_SOURCE: string = 'AppInsightsApplicationCustomizer';
 
 export interface IAppInsightsApplicationCustomizerProperties {
-  
+  appInsightsKey: string;
 }
 
-/** A Custom Action which can be run during execution of a Client Side Application */
 export default class AppInsightsApplicationCustomizer
   extends BaseApplicationCustomizer<IAppInsightsApplicationCustomizerProperties> {
 
@@ -21,13 +20,10 @@ export default class AppInsightsApplicationCustomizer
   public onInit(): Promise<void> {
     Log.info(LOG_SOURCE, `Initialized ${strings.Title}`);
 
-    // Update this to your Azure Application Insights Instrumentation Key
-    let appInsightsKey = "a09f32d3-479e-4782-b6db-1bdce04536db";
-
     let appInsightsScript: string = `var appInsights=window.appInsights||function(a){
   function b(a){c[a]=function(){var b=arguments;c.queue.push(function(){c[a].apply(c,b)})}}var c={config:a},d=document,e=window;setTimeout(function(){var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)});try{c.cookie=d.cookie}catch(a){}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){var i=g&&g(a,b,d,e,h);return!0!==i&&c["_"+f](a,b,d,e,h),i}}return c
     }({
-      instrumentationKey: "` + appInsightsKey + `"
+      instrumentationKey: "` + this.properties.appInsightsKey + `"
     });
   window.appInsights=appInsights,appInsights.queue&&0===appInsights.queue.length&&appInsights.trackPageView();`;
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | yes                               |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?
Minor update to the Application Insights extension:
- Store the Application Insights instrumentation key as a component property so that it is not pushed to the CDN with the JS files
- Made the solution compatible with tenant wide deployment
- Updated the solution to target SPFx 1.9.1