### PR TITLE
fix case of asset filename

### DIFF
--- a/samples/react-application-injectcss/config/package-solution.json
+++ b/samples/react-application-injectcss/config/package-solution.json
@@ -16,7 +16,7 @@
         "assets": {
           "elementManifests": [
             "elements.xml",
-            "clientsideinstance.xml"
+            "ClientSideInstance.xml"
           ]
         }
       }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? |  |

## What's in this Pull Request?

Building package fails on Linux with:
```
Found Element Manifest: elements.xml
Error - 'package-solution sub task errored'
Could not find Element Manifest: sharepoint/assets/clientsideinstance.xml
```

Seems that this extension was generated with buggy yo recipe, as described here: https://github.com/SharePoint/sp-dev-docs/issues/4005

